### PR TITLE
BaSP-TG-93: implemented buttons in delete modal

### DIFF
--- a/src/Components/Admin/TimeSheets/FormAdd/form.module.css
+++ b/src/Components/Admin/TimeSheets/FormAdd/form.module.css
@@ -7,7 +7,6 @@
   align-items: flex-end;
   align-content: space-between;
   row-gap: 10px;
-  overflow: auto;
 }
 
 .form button {

--- a/src/Components/Admin/TimeSheets/FormEdit/form.module.css
+++ b/src/Components/Admin/TimeSheets/FormEdit/form.module.css
@@ -7,7 +7,6 @@
   align-items: flex-end;
   align-content: space-between;
   row-gap: 10px;
-  overflow: auto;
 }
 
 .form button {

--- a/src/Components/Shared/confirmationModal/confirmModal.jsx
+++ b/src/Components/Shared/confirmationModal/confirmModal.jsx
@@ -23,8 +23,8 @@ const ConfirmModal = ({ isOpen, handleClose, confirmDelete, title, message }) =>
         </div>
         <div className={styles.message}>{message}</div>
         <div className={styles.modalButton}>
-          <ButtonText clickAction={confirmDelete} className={styles.Button} label={'Confirm'} />
-          <ButtonText clickAction={handleClose} className={styles.Button} label={'Close'} />
+          <ButtonText clickAction={confirmDelete} label={'Confirm'} />
+          <ButtonText clickAction={handleClose} label={'Close'} />
         </div>
       </div>
     </div>

--- a/src/Components/Shared/confirmationModal/confirmModal.jsx
+++ b/src/Components/Shared/confirmationModal/confirmModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styles from './confirmModal.module.css';
 import { useEffect } from 'react';
+import { ButtonText } from 'Components/Shared';
 
 const ConfirmModal = ({ isOpen, handleClose, confirmDelete, title, message }) => {
   if (!isOpen) {
@@ -22,12 +23,8 @@ const ConfirmModal = ({ isOpen, handleClose, confirmDelete, title, message }) =>
         </div>
         <div className={styles.message}>{message}</div>
         <div className={styles.modalButton}>
-          <button onClick={confirmDelete} className={styles.Button}>
-            Confirm
-          </button>
-          <button onClick={handleClose} className={styles.Button}>
-            Cancel
-          </button>
+          <ButtonText clickAction={confirmDelete} className={styles.Button} label={'Confirm'} />
+          <ButtonText clickAction={handleClose} className={styles.Button} label={'Close'} />
         </div>
       </div>
     </div>

--- a/src/Components/Shared/confirmationModal/confirmModal.module.css
+++ b/src/Components/Shared/confirmationModal/confirmModal.module.css
@@ -71,6 +71,7 @@
   flex-direction: row-reverse;
   justify-content: space-around;
   width: 70%;
+  padding-bottom: 15px;
 }
 
 .Button {

--- a/src/Components/Shared/confirmationModal/confirmModal.module.css
+++ b/src/Components/Shared/confirmationModal/confirmModal.module.css
@@ -73,13 +73,3 @@
   width: 70%;
   padding-bottom: 15px;
 }
-
-.Button {
-  background-color: #76a068;
-  font-size: 16px;
-  border-radius: 5px;
-  padding: 10px 20px;
-  align-self: center;
-  margin-top: 10px;
-  margin-bottom: 15px;
-}


### PR DESCRIPTION
Implemented Buttons from Shared Components  in the delete modal and in the new screens.

**Expected results:**
That the 'confirm' and 'cancel' buttons in the delete modal are the same in all entities, using the shared components of the ButtonText.